### PR TITLE
Update version of official schema

### DIFF
--- a/hy-gml/official-schema-validation.md
+++ b/hy-gml/official-schema-validation.md
@@ -11,7 +11,7 @@
 * Validate each document against the latest INSPIRE official schema(s), using strict XML schema validation. 
   The official schemas for this data theme are:
   *  Hydro Network: https://inspire.ec.europa.eu/schemas/hy-n/4.0/HydroNetwork.xsd
-  *  Hydro Physical Waters: https://inspire.ec.europa.eu/schemas/hy-p/4.0/HydroPhysicalWaters.xsd
+  *  Hydro Physical Waters: https://inspire.ec.europa.eu/schemas/hy-p/5.0/HydroPhysicalWaters.xsd
 
 **Reference(s)**: 
 


### PR DESCRIPTION
The version of the official schema(s) was updated according to the latest application schema release (https://github.com/INSPIRE-MIF/application-schemas/releases/tag/2024.1).
See the related validator issue for reference: https://github.com/INSPIRE-MIF/helpdesk-validator/issues/1027